### PR TITLE
Fix null varaible in macro.

### DIFF
--- a/WebAppUtils.nsh
+++ b/WebAppUtils.nsh
@@ -74,7 +74,11 @@
 ;                to the correct location/name: $DEST_REAL\Web.config
 ; SEC_ID_DEF   - The name of the macro to define containing the section ID.
 !MACRO WebApplicationWithSecID SOURCE DEST_REAL DEST_VIRT DISPLAY_NAME DEFAULT_DOC WEB_CONFIG SEC_ID_DEF
-  !INSERTMACRO WebApplicationCopyFiles "${SOURCE}" "${DEST_REAL}" "${DISPLAY_NAME}" ${SEC_ID_DEF}
+  !if "${SEC_ID_DEF}" = ""
+      !INSERTMACRO WebApplicationCopyFiles "${SOURCE}" "${DEST_REAL}" "${DISPLAY_NAME}" ""
+  !else
+      !INSERTMACRO WebApplicationCopyFiles "${SOURCE}" "${DEST_REAL}" "${DISPLAY_NAME}" ${SEC_ID_DEF}
+  !endif
   !INSERTMACRO RestOfWebProj "${DEST_REAL}" "${DEST_VIRT}" "" "" "${DISPLAY_NAME}" "${DEFAULT_DOC}" "${WEB_CONFIG}" "" "" "yes" "Web"
 !MACROEND
 


### PR DESCRIPTION
It seems that if passing an emptry string to a macro and then passing that
variable to another macro will result in the second macro thinking that the
value is not set. This will cause the compiler to fail. To get around this we
stringify the variable and compare it an empty string before deciding how to
call the next macro.
