### PR TITLE
Make Scripts and Images directories optional.

### DIFF
--- a/WebAppUtils.nsh
+++ b/WebAppUtils.nsh
@@ -278,11 +278,11 @@
 		SetOutPath ${DEST_REAL}\Content
 		File /r ${SOURCE}\Content\*
 		SetOutPath ${DEST_REAL}\Images
-		File /r ${SOURCE}\Images\*
+		File /nonfatal /r ${SOURCE}\Images\*
 		SetOutPath ${DEST_REAL}\bin
 		File ${SOURCE}\bin\*.dll
 		SetOutPath ${DEST_REAL}\Scripts
-		File /r ${SOURCE}\Scripts\*
+		File /nonfatal /r ${SOURCE}\Scripts\*
 
 	!INSERTMACRO RestOfWebProj "${DEST_REAL}" "${DEST_VIRT}" "${WEBSITE_NAME}" "${APP_POOL_NAME}" "${DISPLAY_NAME}" "${DEFAULT_DOC}" "${WEB_CONFIG}" "" "4" "yes" "REST"
 !MACROEND


### PR DESCRIPTION
In some cases (particularly with an API) websites that should be deployed as
MVC4 but which are missing certain (optional) directories will cause the NSIS
scripts to fail to compile because the existance of those directories is
required. This change allows for some directories to be missing from the
source folder without causing such errors.
